### PR TITLE
Change the architecture of LattePanda Mu from aarch64 to x86_64

### DIFF
--- a/web/data/results.yml
+++ b/web/data/results.yml
@@ -829,7 +829,7 @@ items:
     linux_recompile_sec: null
 
 - name: LattePanda Mu
-  arch: aarch64
+  arch: x86_64
   link: https://github.com/geerlingguy/sbc-reviews/issues/42
   price_as_tested: 139.00
   year: 2024


### PR DESCRIPTION
Updates the LattePanda Mu architecture from aarch64 to x86_64 in the results.yaml, due to it being powered by a N100.